### PR TITLE
MNT-132: Raw time-series endpoint for mini sparkline charts

### DIFF
--- a/odin/api/v1/core/serializers.py
+++ b/odin/api/v1/core/serializers.py
@@ -2,6 +2,7 @@ from django.db.models import TextChoices
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from odin.api.utils.serializers import BaseSerializer
 from odin.apps.core.models import Browser
 
 
@@ -36,3 +37,8 @@ class ChartTypeSerializer(serializers.Serializer):
         allow_null=False,
     )
     metric = serializers.ChoiceField(choices=MetricChoices.choices)
+
+
+class WeatherChartQueryParamsSerializer(BaseSerializer):
+    start = serializers.DateTimeField(required=False)
+    end = serializers.DateTimeField(required=False)

--- a/odin/api/v1/core/urls.py
+++ b/odin/api/v1/core/urls.py
@@ -1,6 +1,13 @@
 from django.urls import path
 
-from odin.api.v1.core.views import ApplicationServerKeyView, ChartView, DeviceView, HealthCheckView, LogsView
+from odin.api.v1.core.views import (
+    ApplicationServerKeyView,
+    ChartView,
+    DeviceView,
+    HealthCheckView,
+    LogsView,
+    WeatherChartView,
+)
 
 
 app_name = "core"
@@ -9,6 +16,7 @@ app_name = "core"
 urlpatterns = [
     path("logs/", LogsView.as_view(), name="logs"),
     path("chart/", ChartView.as_view(), name="chart"),
+    path("weather-chart/", WeatherChartView.as_view(), name="weather-chart"),
     path("healthcheck/", HealthCheckView.as_view(), name="healthcheck"),
     path("devices/", DeviceView.as_view(), name="devices"),
     path("app-server-key/", ApplicationServerKeyView.as_view(), name="app-server-key"),

--- a/odin/api/v1/core/views.py
+++ b/odin/api/v1/core/views.py
@@ -8,9 +8,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from odin.api.v1.core.serializers import ChartTypeSerializer, DeviceSubscriptionSerializer, LogSerializer
+from odin.api.v1.core.serializers import (
+    ChartTypeSerializer,
+    DeviceSubscriptionSerializer,
+    LogSerializer,
+    WeatherChartQueryParamsSerializer,
+)
 from odin.apps.core.models import Device, Log
 from odin.apps.core.utils import create_metric_gauge_chart
+from odin.apps.weather.services import get_weather_chart_data
 
 
 class ApplicationServerKeyView(APIView):
@@ -72,3 +78,14 @@ class ChartView(RetrieveAPIView):
 
         contents = create_metric_gauge_chart(**serializer.validated_data)
         return HttpResponse(contents, content_type="image/svg+xml")
+
+
+class WeatherChartView(APIView):
+    authentication_classes = []
+    permission_classes = (AllowAny,)
+
+    def get(self, request: Request) -> Response:
+        serializer = WeatherChartQueryParamsSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        data = get_weather_chart_data(**serializer.validated_data)
+        return Response(data)

--- a/odin/apps/weather/services.py
+++ b/odin/apps/weather/services.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from django.utils import timezone
+
+from odin.apps.weather.models import Weather
+
+
+def get_weather_chart_data(start: datetime | None = None, end: datetime | None = None) -> dict[str, Any]:
+    end_dt = end or timezone.now()
+    start_dt = start or (end_dt - timedelta(hours=48))
+
+    entries = Weather.objects.filter(period__range=(start_dt, end_dt)).order_by("period")
+
+    timestamps: list[str] = []
+    temp: list[float | None] = []
+    humidity: list[float | None] = []
+    pressure: list[int | None] = []
+
+    for entry in entries:
+        timestamps.append(entry.period.isoformat())
+
+        t_avg = entry.data.get("temp")
+        if t_avg is not None and t_avg.get("avg") is not None:
+            temp.append(float(t_avg["avg"]))
+        else:
+            temp.append(None)
+
+        h = entry.data.get("humidity")
+        if h is not None:
+            humidity.append(float(h))
+        else:
+            humidity.append(None)
+
+        p = entry.data.get("pressure")
+        if p is not None:
+            pressure.append(int(p))
+        else:
+            pressure.append(None)
+
+    return {
+        "timestamps": timestamps,
+        "temp": temp,
+        "humidity": humidity,
+        "pressure": pressure,
+    }

--- a/odin/tests/api/test_weather_chart.py
+++ b/odin/tests/api/test_weather_chart.py
@@ -1,0 +1,140 @@
+from datetime import timedelta
+
+import pytest
+
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from odin.tests.factories import WeatherFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+class TestWeatherChartAPI:
+    def setup_method(self):
+        self.client = APIClient()
+        self.url = reverse("api:v1:core:weather-chart")
+
+    @pytest.mark.parametrize("method", ["post", "put", "patch", "delete"])
+    def test_weather_chart__not_allowed_methods(self, method):
+        test_client_callable = getattr(self.client, method)
+        response = test_client_callable(self.url, format="json")
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_weather_chart__empty_when_no_data(self):
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {
+            "timestamps": [],
+            "temp": [],
+            "humidity": [],
+            "pressure": [],
+        }
+
+    def test_weather_chart__returns_three_metrics(self):
+        now = timezone.now()
+        WeatherFactory(period=now)
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert "timestamps" in response.data
+        assert "temp" in response.data
+        assert "humidity" in response.data
+        assert "pressure" in response.data
+        assert len(response.data["timestamps"]) == 1
+
+    def test_weather_chart__temp_values_are_floats(self):
+        now = timezone.now()
+        WeatherFactory(period=now)
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        temp_values = response.data["temp"]
+        assert len(temp_values) == 1
+        assert temp_values[0] is None or isinstance(temp_values[0], float)
+
+    def test_weather_chart__pressure_is_hpa(self):
+        now = timezone.now()
+        WeatherFactory(period=now)
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        pressure_values = response.data["pressure"]
+        assert len(pressure_values) == 1
+        p = pressure_values[0]
+        assert p is None or (isinstance(p, int) and 670 <= p <= 810), f"expected hPa value in [670, 810], got {p}"
+
+    def test_weather_chart__timestamps_ascending(self):
+        now = timezone.now()
+        for hours_ago in [3, 2, 1]:
+            WeatherFactory(period=now - timedelta(hours=hours_ago))
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        timestamps = response.data["timestamps"]
+        assert timestamps == sorted(timestamps)
+
+    def test_weather_chart__respects_start_param(self):
+        now = timezone.now()
+        WeatherFactory(period=now - timedelta(hours=1))
+        WeatherFactory(period=now)
+
+        start = (now - timedelta(minutes=30)).isoformat()
+        response = self.client.get(self.url, {"start": start}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["timestamps"]) == 1
+
+    def test_weather_chart__respects_end_param(self):
+        now = timezone.now()
+        WeatherFactory(period=now - timedelta(hours=2))
+        WeatherFactory(period=now)
+
+        end = (now - timedelta(hours=1)).isoformat()
+        response = self.client.get(self.url, {"end": end}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["timestamps"]) == 1
+
+    def test_weather_chart__default_window_48h(self):
+        now = timezone.now()
+        WeatherFactory(period=now - timedelta(hours=47))
+        WeatherFactory(period=now - timedelta(hours=49))
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["timestamps"]) == 1
+
+    def test_weather_chart__multiple_entries(self):
+        now = timezone.now()
+        for hours_ago in range(5):
+            WeatherFactory(period=now - timedelta(hours=hours_ago))
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["timestamps"]) == 5
+        assert len(response.data["temp"]) == 5
+        assert len(response.data["humidity"]) == 5
+        assert len(response.data["pressure"]) == 5
+
+    def test_weather_chart__none_for_missing_metrics(self):
+        now = timezone.now()
+        WeatherFactory(
+            period=now,
+            data={"temp": None, "humidity": None, "pressure": None},
+        )
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["temp"] == [None]
+        assert response.data["humidity"] == [None]
+        assert response.data["pressure"] == [None]
+
+    def test_weather_chart__invalid_start_format(self):
+        response = self.client.get(self.url, {"start": "not-a-date"}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_weather_chart__invalid_end_format(self):
+        response = self.client.get(self.url, {"end": "garbage"}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/odin/tests/factories.py
+++ b/odin/tests/factories.py
@@ -93,9 +93,9 @@ class VoltageLogFactory(DjangoModelFactory):
 
 
 class WeatherDataFactory(factory.DictFactory):
-    temp = str(FuzzyDecimal(low=-10, high=40, precision=2))
-    pressure = str(FuzzyDecimal(low=670, high=810, precision=2))
-    humidity = str(FuzzyDecimal(low=0, high=100, precision=2))
+    temp = {"avg": "22.50"}
+    pressure = 750
+    humidity = "55"
 
 
 class WeatherFactory(DjangoModelFactory):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "odin"
-version = "1.13.0"
+version = "1.14.0"
 description = "Django application that provides several IoT dashboards and services for Coruscant and Centax projects."
 readme = "README.md"
 requires-python = ">=3.13.6,<3.14.0"

--- a/uv.lock
+++ b/uv.lock
@@ -645,7 +645,7 @@ wheels = [
 
 [[package]]
 name = "odin"
-version = "1.13.0"
+version = "1.14.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a weather chart API endpoint with optional start and end date-time filters.
  - Returns timestamps, temperature, humidity, and pressure series for charting.
  - Uses a default 48-hour reporting window when dates are not provided.
  - Represents unavailable weather metrics as empty values.

- **Bug Fixes**
  - Added validation for invalid date-time query parameters.

- **Tests**
  - Added coverage for filtering, ordering, data formats, missing metrics, and unsupported methods.

- **Release**
  - Updated the application version to 1.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->