### PR TITLE
MNT-133: Basic shared component library

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -53,12 +53,30 @@ frontend/
 ├── index.html              # Vite HTML entrypoint
 ├── src/
 │   ├── main.tsx            # app entry + router
-│   ├── App.tsx             # root layout
-│   ├── components/         # shared UI components
-│   │   └── Header.tsx
+│   ├── App.tsx             # root layout (uses Layout component)
+│   ├── components/
+│   │   ├── Header.tsx      # site header with nav
+│   │   ├── icons/
+│   │   │   └── Icon.tsx    # icon component (graph, settings, cooling, heating)
+│   │   ├── layout/
+│   │   │   ├── Container.tsx  # wrapper with .container class, fluid/breakpoint support
+│   │   │   └── Layout.tsx     # header + main container layout
+│   │   ├── tile/
+│   │   │   ├── AliveIndicator.tsx  # colored status dot (alive/dead/heating/cooling)
+│   │   │   └── Tile.tsx            # dashboard card shell (title, status, icon link, body)
+│   │   ├── grid/
+│   │   │   └── ResponsiveGrid.tsx  # responsive column grid
+│   │   ├── modal/
+│   │   │   └── Modal.tsx           # modal overlay with Escape/backdrop close
+│   │   └── form/
+│   │       ├── Form.tsx             # form wrapper
+│   │       ├── TextField.tsx        # text/number input with label
+│   │       ├── SubmitButton.tsx     # submit button (primary/secondary/outline)
+│   │       └── FieldStatus.tsx      # inline validation message (error/info/success)
 │   ├── pages/              # route components (lazy-loaded)
 │   │   ├── DashboardPage.tsx
 │   │   ├── SensorChartPage.tsx
+│   │   ├── StyleguidePage.tsx  # component styleguide
 │   │   └── NotFoundPage.tsx
 │   ├── lib/
 │   │   ├── config.ts       # env-based config (API base URL, admin URL)
@@ -66,7 +84,9 @@ frontend/
 │   │       ├── client.ts
 │   │       └── sensors.ts
 │   └── styles/
-│       └── app.css
+│       ├── app.css         # global resets / base theme
+│       ├── components.css  # tile, modal, alive-indicator, form primitives
+│       └── responsive.css  # mobile/tablet/large-tablet breakpoints
 ├── biome.json
 ├── tsconfig.json
 └── vite.config.ts
@@ -79,7 +99,33 @@ Routes mirror the existing Django pages:
 - `/` — dashboard (replaces `index.html`)
 - `/sensors/home` — home temperature chart (replaces `sensors_home`)
 - `/sensors/boiler` — boiler temperature chart (replaces `sensors_boiler`)
+- `/styleguide` — component styleguide with every state visible
 - `*` — 404 placeholder
+
+## Shared components
+
+All presentational, no dashboard-specific business logic. Parameterized via props.
+
+| Component | File | Description |
+|-----------|------|-------------|
+| `Container` | `src/components/layout/Container.tsx` | Wraps children in `.container` class; accepts `as` (element type) and `fluid` (no max-width). |
+| `Layout` | `src/components/layout/Layout.tsx` | Composes `<Header />` + `<main className="container">`. Used by `App.tsx`. |
+| `ResponsiveGrid` | `src/components/grid/ResponsiveGrid.tsx` | CSS grid container; 3 columns (>1400px) → 2 columns (769-1400px) → 1 column (≤768px). |
+| `Tile` | `src/components/tile/Tile.tsx` | Dashboard card shell — `title`, optional `status` (AliveState), optional `iconLink` (ReactNode), and `children` body slot. |
+| `AliveIndicator` | `src/components/tile/AliveIndicator.tsx` | 8px colored dot; states: `alive` (#4caf50), `dead` (#f44336), `heating` (#f44336), `cooling` (#007190). |
+| `Modal` | `src/components/modal/Modal.tsx` | Fixed overlay with `open`/`onClose` control; Escape key and backdrop-click dismiss; `title`, `children` (body slot), optional `message`. |
+| `Icon` | `src/components/icons/Icon.tsx` | Renders `<img>` referencing `/static/img/{name}.svg` via the Vite proxy. Names: `graph`, `settings`, `cooling`, `heating`. |
+| `Form` | `src/components/form/Form.tsx` | `<form>` wrapper with `onSubmit`. |
+| `TextField` | `src/components/form/TextField.tsx` | Text/number input with `<label>`. Props: `id`, `label`, `value`, `onChange`, `type`, `name`, `step`, `required`, `autoComplete`. |
+| `SubmitButton` | `src/components/form/SubmitButton.tsx` | Styled button; `label`, `variant` (primary/secondary/outline), `disabled`, plus any `<button>` attributes. |
+| `FieldStatus` | `src/components/form/FieldStatus.tsx` | Inline validation message; `tone` (error/info/success), `children`. |
+
+### CSS
+
+- `src/styles/components.css` — tile, grid, modal, alive-indicator, form styles (ported from `odin/static/css/index/base.css`, `index/sensors.css`, `modal.css`, and `base.css`).
+- `src/styles/responsive.css` — breakpoint overrides matching the four existing breakpoints (≤480, 481-768, 769-1024, 1025-1400).
+
+Icons are served by Django's static file server via the Vite dev proxy (`/static/img/*`), consistent with `Header.tsx`'s logo reference.
 
 ## API client
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,10 @@
-import { Header } from "@/components/Header";
+import { Layout } from "@/components/layout/Layout";
 import { Outlet } from "react-router-dom";
 
 export function App() {
   return (
-    <>
-      <Header />
-      <main className="container">
-        <Outlet />
-      </main>
-    </>
+    <Layout>
+      <Outlet />
+    </Layout>
   );
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/sensors/home", label: "Home (chart)" },
   { to: "/sensors/boiler", label: "Boiler (chart)" },
+  { to: "/styleguide", label: "Styleguide" },
 ];
 
 export function Header() {

--- a/frontend/src/components/form/FieldStatus.tsx
+++ b/frontend/src/components/form/FieldStatus.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+interface FieldStatusProps {
+  tone?: "error" | "info" | "success";
+  children: ReactNode;
+}
+
+export function FieldStatus({ tone = "error", children }: FieldStatusProps) {
+  return (
+    <div className={`form__status form__status--${tone}`} role={tone === "error" ? "alert" : "status"}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/form/Form.tsx
+++ b/frontend/src/components/form/Form.tsx
@@ -1,0 +1,16 @@
+import type { FormEventHandler, ReactNode } from "react";
+
+interface FormProps {
+  onSubmit: FormEventHandler<HTMLFormElement>;
+  children: ReactNode;
+  className?: string;
+}
+
+export function Form({ onSubmit, children, className }: FormProps) {
+  const cls = ["form", className].filter(Boolean).join(" ");
+  return (
+    <form className={cls} onSubmit={onSubmit}>
+      {children}
+    </form>
+  );
+}

--- a/frontend/src/components/form/SubmitButton.tsx
+++ b/frontend/src/components/form/SubmitButton.tsx
@@ -1,0 +1,15 @@
+import type { ButtonHTMLAttributes } from "react";
+
+interface SubmitButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  variant?: "primary" | "secondary" | "outline";
+}
+
+export function SubmitButton({ label, variant = "primary", className, type = "submit", ...rest }: SubmitButtonProps) {
+  const cls = [`form__button form__button--${variant}`, className].filter(Boolean).join(" ");
+  return (
+    <button type={type} className={cls} {...rest}>
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/form/TextField.tsx
+++ b/frontend/src/components/form/TextField.tsx
@@ -1,0 +1,44 @@
+import type { ChangeEventHandler } from "react";
+
+interface TextFieldProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  type?: "text" | "number";
+  name?: string;
+  step?: string;
+  required?: boolean;
+  autoComplete?: string;
+}
+
+export function TextField({
+  id,
+  label,
+  value,
+  onChange,
+  type = "text",
+  name,
+  step,
+  required,
+  autoComplete,
+}: TextFieldProps) {
+  return (
+    <div className="form__group">
+      <label className="form__label" htmlFor={id}>
+        {label}
+      </label>
+      <input
+        className="form__input"
+        id={id}
+        type={type}
+        name={name}
+        value={value}
+        onChange={onChange}
+        step={step}
+        required={required}
+        autoComplete={autoComplete}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/grid/ResponsiveGrid.tsx
+++ b/frontend/src/components/grid/ResponsiveGrid.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+interface ResponsiveGridProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function ResponsiveGrid({ children, className }: ResponsiveGridProps) {
+  const cls = ["grid", className].filter(Boolean).join(" ");
+  return <div className={cls}>{children}</div>;
+}

--- a/frontend/src/components/icons/Icon.tsx
+++ b/frontend/src/components/icons/Icon.tsx
@@ -1,0 +1,19 @@
+const ICON_PATHS: Record<string, string> = {
+  graph: "/static/img/graph.svg",
+  settings: "/static/img/settings.svg",
+  cooling: "/static/img/cooling.svg",
+  heating: "/static/img/heating.svg",
+};
+
+export type IconName = keyof typeof ICON_PATHS;
+
+interface IconProps {
+  name: IconName;
+  alt: string;
+  width?: number;
+  className?: string;
+}
+
+export function Icon({ name, alt, width = 16, className }: IconProps) {
+  return <img src={ICON_PATHS[name]} alt={alt} width={width} className={className} />;
+}

--- a/frontend/src/components/layout/Container.tsx
+++ b/frontend/src/components/layout/Container.tsx
@@ -1,0 +1,13 @@
+import type { ElementType, ReactNode } from "react";
+
+interface ContainerProps {
+  as?: ElementType;
+  fluid?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+export function Container({ as: As = "div", fluid = false, className, children }: ContainerProps) {
+  const cls = ["container", fluid && "container--fluid", className].filter(Boolean).join(" ");
+  return <As className={cls}>{children}</As>;
+}

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,0 +1,15 @@
+import { Header } from "@/components/Header";
+import type { ReactNode } from "react";
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export function Layout({ children }: LayoutProps) {
+  return (
+    <>
+      <Header />
+      <main className="container">{children}</main>
+    </>
+  );
+}

--- a/frontend/src/components/modal/Modal.tsx
+++ b/frontend/src/components/modal/Modal.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from "react";
+import { useEffect, useId, useRef } from "react";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  message?: string;
+}
+
+export function Modal({ open, onClose, title, children, message }: ModalProps) {
+  const id = useId();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const suppressCloseRef = useRef(false);
+
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+
+    if (open) {
+      suppressCloseRef.current = false;
+      el.showModal();
+    } else if (el.open) {
+      suppressCloseRef.current = true;
+      el.close();
+    }
+
+    return () => {
+      if (el.open) {
+        suppressCloseRef.current = true;
+        el.close();
+      }
+    };
+  }, [open]);
+
+  useEffect(() => {
+    const el = dialogRef.current;
+    if (!el) return;
+
+    const handleClose = () => {
+      if (suppressCloseRef.current) {
+        suppressCloseRef.current = false;
+        return;
+      }
+      onClose();
+    };
+
+    el.addEventListener("close", handleClose);
+    return () => el.removeEventListener("close", handleClose);
+  }, [onClose]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={`modal${open ? " modal--open" : ""}`}
+      aria-labelledby={`${id}-title`}
+      onClick={(e) => {
+        if (e.target === dialogRef.current) {
+          onClose();
+        }
+      }}
+      onKeyDown={(e) => {
+        if ((e.key === "Enter" || e.key === " ") && e.target === dialogRef.current) {
+          onClose();
+        }
+      }}
+    >
+      <div className="modal__body">
+        <div className="modal__header">
+          <h2 className="modal__title" id={`${id}-title`}>
+            {title}
+          </h2>
+          <button type="button" className="modal__close" aria-label="Close" onClick={onClose}>
+            &times;
+          </button>
+        </div>
+        {children}
+        {message !== undefined && <div className="modal__message">{message}</div>}
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/src/components/tile/AliveIndicator.tsx
+++ b/frontend/src/components/tile/AliveIndicator.tsx
@@ -1,0 +1,9 @@
+export type AliveState = "alive" | "dead" | "heating" | "cooling";
+
+interface AliveIndicatorProps {
+  state: AliveState;
+}
+
+export function AliveIndicator({ state }: AliveIndicatorProps) {
+  return <span className={`alive-indicator alive-indicator--${state}`} aria-label={state} />;
+}

--- a/frontend/src/components/tile/Tile.tsx
+++ b/frontend/src/components/tile/Tile.tsx
@@ -1,0 +1,22 @@
+import { AliveIndicator, type AliveState } from "@/components/tile/AliveIndicator";
+import type { ReactNode } from "react";
+
+interface TileProps {
+  title: string;
+  status?: AliveState;
+  iconLink?: ReactNode;
+  children: ReactNode;
+}
+
+export function Tile({ title, status, iconLink, children }: TileProps) {
+  return (
+    <section className="tile">
+      <h2 className="tile__title">
+        {status && <AliveIndicator state={status} />}
+        <span className="tile__title-text">{title}</span>
+        {iconLink && <span className="tile__icon">{iconLink}</span>}
+      </h2>
+      <div className="tile__body">{children}</div>
+    </section>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,8 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import "@/styles/app.css";
+import "@/styles/components.css";
+import "@/styles/responsive.css";
 
 const router = createBrowserRouter([
   {
@@ -13,6 +15,10 @@ const router = createBrowserRouter([
       {
         path: "sensors/:location",
         lazy: async () => ({ Component: (await import("@/pages/SensorChartPage")).SensorChartPage }),
+      },
+      {
+        path: "styleguide",
+        lazy: async () => ({ Component: (await import("@/pages/StyleguidePage")).StyleguidePage }),
       },
       { path: "*", lazy: async () => ({ Component: (await import("@/pages/NotFoundPage")).NotFoundPage }) },
     ],

--- a/frontend/src/pages/StyleguidePage.tsx
+++ b/frontend/src/pages/StyleguidePage.tsx
@@ -1,0 +1,159 @@
+import { FieldStatus } from "@/components/form/FieldStatus";
+import { Form } from "@/components/form/Form";
+import { SubmitButton } from "@/components/form/SubmitButton";
+import { TextField } from "@/components/form/TextField";
+import { ResponsiveGrid } from "@/components/grid/ResponsiveGrid";
+import { Icon } from "@/components/icons/Icon";
+import { Modal } from "@/components/modal/Modal";
+import { AliveIndicator } from "@/components/tile/AliveIndicator";
+import type { AliveState } from "@/components/tile/AliveIndicator";
+import { Tile } from "@/components/tile/Tile";
+import { useState } from "react";
+
+const ALIVE_STATES: { state: AliveState; label: string }[] = [
+  { state: "alive", label: "Alive (#4caf50)" },
+  { state: "dead", label: "Dead (#f44336)" },
+  { state: "heating", label: "Heating (#f44336)" },
+  { state: "cooling", label: "Cooling (#007190)" },
+];
+
+export function StyleguidePage() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+
+  return (
+    <section>
+      <h2>Styleguide</h2>
+      <p>Shared presentational components for the Odin dashboard.</p>
+
+      <section>
+        <h3>AliveIndicator</h3>
+        <p>Four states rendered inline:</p>
+        <p>
+          {ALIVE_STATES.map(({ state, label }) => (
+            <span
+              key={state}
+              style={{ marginRight: "1rem", display: "inline-flex", alignItems: "center", gap: "0.35rem" }}
+            >
+              <AliveIndicator state={state} />
+              <span>{label}</span>
+            </span>
+          ))}
+        </p>
+      </section>
+
+      <section>
+        <h3>Icon</h3>
+        <p style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+          <Icon name="graph" alt="graph" />
+          <Icon name="settings" alt="settings" width={20} />
+          <Icon name="cooling" alt="cooling" width={20} />
+          <Icon name="heating" alt="heating" width={20} />
+        </p>
+      </section>
+
+      <section>
+        <h3>Tile</h3>
+        <p>Tiles with title, optional status dot, optional icon link, and body slot:</p>
+        <ResponsiveGrid>
+          <Tile
+            title="Sensors"
+            status="alive"
+            iconLink={
+              <a href="/styleguide">
+                <Icon name="graph" alt="graph" />
+              </a>
+            }
+          >
+            <p>Tile body content goes here. This tile has status=alive and a graph icon link.</p>
+          </Tile>
+
+          <Tile
+            title="Boiler Room"
+            status="dead"
+            iconLink={
+              <a href="/styleguide">
+                <Icon name="graph" alt="graph" />
+              </a>
+            }
+          >
+            <p>Tile body content. This tile has status=dead and a graph icon link.</p>
+          </Tile>
+
+          <Tile title="Weather">
+            <p>Tile without status indicator or icon link.</p>
+          </Tile>
+        </ResponsiveGrid>
+      </section>
+
+      <section>
+        <h3>Modal</h3>
+        <SubmitButton label="Open modal" variant="primary" onClick={() => setModalOpen(true)} />
+        <Modal
+          open={modalOpen}
+          onClose={() => setModalOpen(false)}
+          title="Set temperature"
+          message={inputValue ? `Sending ${inputValue}°C…` : undefined}
+        >
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+            }}
+          >
+            <input type="hidden" name="sensor_id" value="sensor-1" />
+            <TextField
+              id="modal-temp-input"
+              label="Temperature °C"
+              type="number"
+              name="target_temp"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              step="0.5"
+              required
+            />
+            <SubmitButton label="Send" variant="primary" />
+          </Form>
+        </Modal>
+      </section>
+
+      <section>
+        <h3>Form primitives</h3>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+          }}
+        >
+          <TextField
+            id="demo-text"
+            label="Text input"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+          />
+          <TextField
+            id="demo-number"
+            label="Number input"
+            type="number"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            step="0.5"
+          />
+          <SubmitButton label="Primary" variant="primary" />
+          <SubmitButton label="Secondary" variant="secondary" />
+          <SubmitButton label="Outline" variant="outline" />
+          <SubmitButton label="Disabled" variant="primary" disabled />
+          <FieldStatus tone="error">Error message (required field)</FieldStatus>
+          <FieldStatus tone="info">Info message</FieldStatus>
+          <FieldStatus tone="success">Success message</FieldStatus>
+        </Form>
+      </section>
+
+      <section>
+        <h3>Container</h3>
+        <p>
+          The <code>Container</code> component is used to wrap content. It renders the <code>.container</code> class
+          (max-width 1560px) and accepts <code>as</code> and <code>fluid</code> props.
+        </p>
+      </section>
+    </section>
+  );
+}

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1,0 +1,287 @@
+/* ============================================================
+   Shared component styles for Odin frontend.
+   Ported from odin/static/css/index/base.css,
+   odin/static/css/index/sensors.css, and
+   odin/static/css/modal.css with BEM naming.
+   ============================================================ */
+
+/* ----- Grid (responsive columns defined in responsive.css) ----- */
+.grid {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-column-gap: 1.5rem;
+  grid-row-gap: 1.5rem;
+  padding-bottom: 2rem;
+}
+
+/* ----- Tile ----- */
+.tile {
+  min-height: 320px;
+  overflow: hidden;
+  border: 1px solid #3d3d3b;
+  background: #1a1a18;
+}
+
+.tile__title {
+  font-weight: 500;
+  text-transform: uppercase;
+  margin-bottom: 0;
+  padding: 0.75rem 1.5rem 0.75rem 1.5rem;
+  background: #242b23;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.tile__title-text {
+  flex: 1;
+}
+
+.tile__icon {
+  float: right;
+  display: flex;
+  align-items: center;
+}
+
+.tile__icon a {
+  display: inline-flex;
+}
+
+.tile__body {
+  padding: 0 1.5rem 2rem 1.5rem;
+}
+
+/* ----- Alive indicator ----- */
+.alive-indicator {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin: 2px 2px 4px 2px;
+  border-radius: 50%;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.alive-indicator--alive {
+  background-color: #4caf50;
+}
+
+.alive-indicator--cooling {
+  background-color: #007190;
+}
+
+.alive-indicator--dead,
+.alive-indicator--heating {
+  background-color: #f44336;
+}
+
+/* ----- Modal ----- */
+.modal {
+  border: none;
+  background: transparent;
+  padding: 0;
+  max-width: 90vw;
+}
+
+.modal::backdrop {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.modal__body {
+  background: #1c1c1c;
+  color: #bfbfbf;
+  border: 1px solid #343a40;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  min-width: 280px;
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  gap: 12px;
+}
+
+.modal__title {
+  font-weight: bold;
+  font-size: 1rem;
+  margin: 0;
+}
+
+.modal__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+  text-align: right;
+  color: inherit;
+  padding: 0;
+  line-height: 1;
+}
+
+.modal form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.modal label {
+  margin: 0;
+  font-weight: bold;
+  font-size: 1rem;
+}
+
+.modal form label {
+  margin-bottom: 0.5rem;
+}
+
+.modal input[type="number"],
+.modal input[type="text"] {
+  width: 100%;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #343a40;
+  border-radius: 6px;
+  font-size: 14px;
+  background: #000;
+  color: #bfbfbf;
+}
+
+.modal button[type="submit"] {
+  padding: 0.5rem;
+  border: none;
+  background: #ff5253;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.modal button[type="submit"]:hover {
+  background: #ff5253;
+}
+
+.modal__message {
+  font-size: 12px;
+  color: #ff5253;
+  min-height: 16px;
+}
+
+/* ----- Form primitives ----- */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form__group {
+  margin-bottom: 1rem;
+}
+
+.form .form__group:last-child {
+  margin-bottom: 0;
+}
+
+.form__label {
+  display: inline;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+
+.form__input {
+  display: inline-block;
+  width: 100%;
+  height: calc(2.25rem + 2px);
+  padding: 0.375rem 0.75rem;
+  color: #bfbfbf;
+  background-color: #1a1a18;
+  background-clip: padding-box;
+  border: 1px solid #3d3d3b;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.form__input:focus {
+  background-color: #242b23;
+  border-color: #82c38b;
+  outline: 0;
+}
+
+.form__button {
+  display: inline-block;
+  min-width: 7.5rem;
+  font-weight: 400;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  user-select: none;
+  padding: 0.5rem 0.75rem;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow
+    0.15s ease-in-out;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  margin: 0;
+}
+
+.form__button--primary {
+  color: #ffffff;
+  background-color: #321e1d;
+  border: 1px solid #ff5253;
+}
+
+.form__button--primary:hover {
+  background-color: #ff5253;
+}
+
+.form__button--secondary {
+  color: #6f6f6f;
+  border: 1px solid #9f9f9f;
+  background-color: #ffffff;
+}
+
+.form__button--secondary:hover {
+  color: #ffffff;
+  background-color: #9f9f9f;
+}
+
+.form__button--outline {
+  color: #bf4b31;
+  border: 1px solid #bf4b31;
+  background-color: #ffffff;
+}
+
+.form__button--outline:hover {
+  color: #ffffff;
+  background-color: #bf4b31;
+  border-color: #bf4b31;
+}
+
+.form__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form__status {
+  font-size: 0.85rem;
+  min-height: 1rem;
+}
+
+.form__status--error {
+  color: #ff5253;
+}
+
+.form__status--info {
+  color: #666;
+}
+
+.form__status--success {
+  color: #4caf50;
+}
+
+/* ----- Container variations ----- */
+.container--fluid {
+  max-width: 100%;
+}

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -1,0 +1,116 @@
+/* ============================================================
+   Responsive breakpoints for shared components.
+   Ported from odin/static/css/responsive/{mobile,small-tablet,tablet,large-tablet}.css
+   Drop dashboard-specific selectors; keep generic component rules.
+   ============================================================ */
+
+/* Mobile: ≤480px (Pixel 7/8) */
+@media (max-width: 480px) {
+  main.container,
+  .container {
+    padding: 0 1rem;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+    grid-row-gap: 0.75rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+
+  .tile {
+    min-height: 300px;
+  }
+
+  .tile__title {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .tile__body {
+    padding: 0.75rem;
+  }
+}
+
+/* Small tablet: 481-768px */
+@media (min-width: 481px) and (max-width: 768px) {
+  main.container,
+  .container {
+    padding: 0 1rem;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+    grid-row-gap: 1rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+
+  .tile {
+    padding: 0.75rem;
+  }
+
+  .tile__title {
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .tile__body {
+    padding: 1rem;
+  }
+}
+
+/* Tablet: 769-1024px (iPad Pro) */
+@media (min-width: 769px) and (max-width: 1024px) {
+  main.container,
+  .container {
+    padding: 0 1rem;
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 1rem;
+    grid-row-gap: 1rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+
+  .tile {
+    padding: 0.75rem 1rem;
+    min-height: 280px;
+  }
+
+  .tile__title {
+    padding: 0.75rem 1rem;
+  }
+
+  .tile__body {
+    padding: 0 1rem 1.25rem;
+  }
+}
+
+/* Large tablet / small laptop: 1025-1400px */
+@media (min-width: 1025px) and (max-width: 1400px) {
+  main.container,
+  .container {
+    padding: 0 1rem;
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 1.25rem;
+    grid-row-gap: 1.25rem;
+  }
+
+  .tile {
+    min-height: 300px;
+  }
+
+  .tile__title {
+    padding: 0.75rem 1.25rem;
+  }
+
+  .tile__body {
+    padding: 0 1.25rem 1.5rem;
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "odin"
-version = "1.14.0"
+version = "1.15.0"
 description = "Django application that provides several IoT dashboards and services for Coruscant and Centax projects."
 readme = "README.md"
 requires-python = ">=3.13.6,<3.14.0"

--- a/uv.lock
+++ b/uv.lock
@@ -645,7 +645,7 @@ wheels = [
 
 [[package]]
 name = "odin"
-version = "1.14.0"
+version = "1.15.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary

This pull request implements the basic shared component library for the dashboard, as outlined in task [MNT-133](https://linear.app/mnt/issue/MNT-133/basic-shared-component-library). The library includes presentational building blocks such as layout, tile, alive indicator, modal, and form components, matching the current visual behavior. The components are built as plain React + TS primitives and are purely presentational, parameterized via props.

### Base Branch: epic/react_frontend

## Changes

* Added `Container` and `Layout` components under `frontend/src/components/layout/`
* Added `Tile` and `AliveIndicator` components under `frontend/src/components/tile/`
* Added `ResponsiveGrid` component under `frontend/src/components/grid/`
* Added `Modal` component under `frontend/src/components/modal/`
* Added form primitives (`Form`, `TextField`, `SubmitButton`, `FieldStatus`) under `frontend/src/components/form/`
* Created `Icon` component to reference existing SVG icons
* Ported visual rules from existing Django CSS into `frontend/src/styles/components.css`
* Added a Styleguide route under `frontend/src/pages/StyleguidePage.tsx`
* Updated `frontend/README.md` to list shared components

## Testing

No testing information available.

## Summary by CodeRabbit

* **New Features**
  * Added a React-based dashboard interface with navigation, responsive layouts, sensor status indicators, forms, modals, and reusable UI components.
  * Added dashboard and sensor views, including sensor counts, details, loading states, reload actions, and error feedback.
  * Added a dashboard API providing weather, sensors, traffic, voltage, exchange rates, system status, and error logs.
* **Documentation**
  * Added setup, configuration, routing, development, and backend integration guidance for the frontend.
* **Tests**
  * Added comprehensive dashboard API coverage, including cached responses and enriched sensor data.