### PR TITLE
MNT-129: Warp theme for React

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,13 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-  <meta name="theme-color" content="#242b23" />
+  <meta name="theme-color" content="#0c0d0e" />
   <meta name="application-name" content="ODIN" />
   <meta name="description" content="ODIN IoT Dashboard - Sensor Management, Weather Monitoring, and Home Automation" />
   <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
   <link rel="stylesheet" href="/static/css/fonts.css" />
-  <link rel="stylesheet" href="/static/css/base.css" />
-  <link rel="stylesheet" href="/static/css/header.css" />
   <title>ODIN Server</title>
 </head>
 <body>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -15,13 +15,13 @@ const NAV_ITEMS: NavItem[] = [
 
 export function Header() {
   return (
-    <header>
-      <h1>
-        <span className="logo">
+    <header className="app-header">
+      <div className="app-header__brand">
+        <span className="app-header__logo">
           <img src="/static/img/logo.png" alt="O" />
         </span>
-        <NavLink to="/">ODIN SERVER</NavLink>
-      </h1>
+        <NavLink to="/">ODIN</NavLink>
+      </div>
       <nav className="menu">
         {NAV_ITEMS.map((item) => (
           <NavLink key={item.to} to={item.to} end={item.end}>

--- a/frontend/src/components/chart/MiniSparkline.tsx
+++ b/frontend/src/components/chart/MiniSparkline.tsx
@@ -1,6 +1,6 @@
 import { Line, LineChart, ResponsiveContainer, Tooltip } from "recharts";
 
-const DEFAULT_COLOR = "rgba(54, 162, 235, 1)";
+const DEFAULT_COLOR = "var(--color-accent)";
 
 interface SparklinePoint {
   timestamp: string;
@@ -38,10 +38,10 @@ export function MiniSparkline({ points, color = DEFAULT_COLOR, height = 48 }: Mi
         />
         <Tooltip
           contentStyle={{
-            background: "#1a1a18",
-            border: "1px solid #3d3d3b",
-            borderRadius: 4,
-            color: "#bfbfbf",
+            background: "var(--color-surface-2)",
+            border: "1px solid var(--color-border)",
+            borderRadius: "var(--radius-sm)",
+            color: "var(--color-text-primary)",
             fontSize: 12,
           }}
         />

--- a/frontend/src/components/chart/TemperatureChart.tsx
+++ b/frontend/src/components/chart/TemperatureChart.tsx
@@ -117,25 +117,25 @@ export function TemperatureChart({ data, options }: TemperatureChartProps) {
   return (
     <ResponsiveContainer width="100%" height={480}>
       <LineChart data={points} margin={{ top: 16, right: 16, bottom: 8, left: 8 }}>
-        <CartesianGrid strokeDasharray="3 3" stroke="#3d3d3b" />
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
         <XAxis
           dataKey="time"
           type="number"
           scale="time"
           domain={["dataMin", "dataMax"]}
           tickFormatter={(ts: number) => format(new Date(ts), "HH:mm")}
-          stroke="#bfbfbf"
-          label={{ value: xTitle, position: "insideBottomRight", offset: -4, fill: "#bfbfbf" }}
+          stroke="var(--color-text-secondary)"
+          label={{ value: xTitle, position: "insideBottomRight", offset: -4, fill: "var(--color-text-secondary)" }}
         />
         <YAxis
           domain={[yMin, yMax]}
           tickFormatter={(v: number) => `${v}°`}
-          stroke="#bfbfbf"
+          stroke="var(--color-text-secondary)"
           label={{
             value: yTitle,
             angle: -90,
             position: "insideLeft",
-            fill: "#bfbfbf",
+            fill: "var(--color-text-secondary)",
             style: { textAnchor: "middle" },
           }}
         />
@@ -149,15 +149,15 @@ export function TemperatureChart({ data, options }: TemperatureChartProps) {
             return v !== null ? `${v.toFixed(1)}°C` : "—";
           }}
           contentStyle={{
-            background: "#1a1a18",
-            border: "1px solid #3d3d3b",
+            background: "var(--color-surface-2)",
+            border: "1px solid var(--color-border)",
             borderRadius: 6,
-            color: "#bfbfbf",
+            color: "var(--color-text-primary)",
           }}
         />
         <Legend
-          wrapperStyle={{ color: "#bfbfbf" }}
-          formatter={(value: string) => <span style={{ color: "#bfbfbf" }}>{value}</span>}
+          wrapperStyle={{ color: "var(--color-text-secondary)" }}
+          formatter={(value: string) => <span style={{ color: "var(--color-text-secondary)" }}>{value}</span>}
         />
         {ids.map((id, i) => (
           <Line

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { App } from "@/App";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
+import "@/styles/tokens.css";
 import "@/styles/app.css";
 import "@/styles/components.css";
 import "@/styles/responsive.css";

--- a/frontend/src/pages/StyleguidePage.tsx
+++ b/frontend/src/pages/StyleguidePage.tsx
@@ -12,11 +12,45 @@ import { Tile } from "@/components/tile/Tile";
 import { useState } from "react";
 
 const ALIVE_STATES: { state: AliveState; label: string }[] = [
-  { state: "alive", label: "Alive (#4caf50)" },
-  { state: "dead", label: "Dead (#f44336)" },
-  { state: "heating", label: "Heating (#f44336)" },
-  { state: "cooling", label: "Cooling (#007190)" },
+  { state: "alive", label: "Alive (success)" },
+  { state: "dead", label: "Dead (error)" },
+  { state: "heating", label: "Heating (error)" },
+  { state: "cooling", label: "Cooling (accent)" },
 ];
+
+const TOKENS = [
+  { name: "--color-bg", value: "#0c0d0e", desc: "Canvas / body background" },
+  { name: "--color-surface-1", value: "#0f1011", desc: "Subtle raised surface" },
+  { name: "--color-surface-2", value: "#141516", desc: "Cards, panels" },
+  { name: "--color-surface-3", value: "#1a1c23", desc: "Modals, dropdowns" },
+  { name: "--color-border", value: "#23252a", desc: "Hairline borders, dividers" },
+  { name: "--color-border-strong", value: "#34343a", desc: "Input focus borders" },
+  { name: "--color-text-primary", value: "#f7f8f8", desc: "Headings, body text" },
+  { name: "--color-text-secondary", value: "#8f93a2", desc: "Muted labels, metadata" },
+  { name: "--color-text-tertiary", value: "#62666d", desc: "Disabled, footnotes" },
+  { name: "--color-accent", value: "#5e6ad2", desc: "Primary buttons, links, focus" },
+  { name: "--color-accent-hover", value: "#828fff", desc: "Accent hover" },
+  { name: "--color-success", value: "#27a644", desc: "Status pills, success" },
+  { name: "--color-error", value: "#ff5370", desc: "Destructive, error states" },
+  { name: "--color-warning", value: "#ffcb6b", desc: "Warning banners" },
+];
+
+function Swatch({ color }: { color: string }) {
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        width: 16,
+        height: 16,
+        borderRadius: 4,
+        background: color,
+        border: "1px solid var(--color-border)",
+        verticalAlign: "middle",
+        marginRight: 8,
+      }}
+    />
+  );
+}
 
 export function StyleguidePage() {
   const [modalOpen, setModalOpen] = useState(false);
@@ -25,7 +59,43 @@ export function StyleguidePage() {
   return (
     <section>
       <h2>Styleguide</h2>
-      <p>Shared presentational components for the Odin dashboard.</p>
+      <p>Shared presentational components for the Odin dashboard, themed with the Warp design system.</p>
+
+      <section>
+        <h3>Theme tokens</h3>
+        <p>
+          Dark-first, near-black canvas with a 4-step surface ladder and lavender-blue accent.{" "}
+          <code>tokens.css</code> defines all variables consumed by component styles.
+        </p>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ borderBottom: "1px solid var(--color-border)" }}>
+              <th style={{ textAlign: "left", padding: "0.5rem 0.75rem", fontSize: "0.8rem" }}>Token</th>
+              <th style={{ textAlign: "left", padding: "0.5rem 0.75rem", fontSize: "0.8rem" }}>Sample</th>
+              <th style={{ textAlign: "left", padding: "0.5rem 0.75rem", fontSize: "0.8rem" }}>Value</th>
+              <th style={{ textAlign: "left", padding: "0.5rem 0.75rem", fontSize: "0.8rem" }}>Usage</th>
+            </tr>
+          </thead>
+          <tbody>
+            {TOKENS.map((token) => (
+              <tr key={token.name} style={{ borderBottom: "1px solid var(--color-border)" }}>
+                <td style={{ padding: "0.4rem 0.75rem", fontFamily: "var(--font-mono)", fontSize: "0.8rem" }}>
+                  {token.name}
+                </td>
+                <td style={{ padding: "0.4rem 0.75rem" }}>
+                  <Swatch color={token.value} />
+                </td>
+                <td style={{ padding: "0.4rem 0.75rem", fontFamily: "var(--font-mono)", fontSize: "0.8rem" }}>
+                  {token.value}
+                </td>
+                <td style={{ padding: "0.4rem 0.75rem", fontSize: "0.8rem", color: "var(--color-text-secondary)" }}>
+                  {token.desc}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
 
       <section>
         <h3>AliveIndicator</h3>
@@ -56,8 +126,8 @@ export function StyleguidePage() {
       <section>
         <h3>MiniSparkline</h3>
         <p>
-          Data-driven inline sparkline. Replaces the server-rendered gauge <code>{"<img>"}</code>. Renders from JSON
-          data (no server round-trip for chart rendering).
+          Data-driven inline sparkline. The default stroke color uses the accent token{" "}
+          <code>var(--color-accent)</code>.
         </p>
         <div style={{ display: "flex", gap: "2rem", alignItems: "center", flexWrap: "wrap" }}>
           <div style={{ width: 120 }}>
@@ -73,7 +143,7 @@ export function StyleguidePage() {
           </div>
           <div style={{ width: 120 }}>
             <MiniSparkline
-              color="rgba(255, 99, 132, 1)"
+              color="var(--color-success)"
               points={[
                 { timestamp: "2026-07-20T10:00:00", value: 30 },
                 { timestamp: "2026-07-20T11:00:00", value: 28 },
@@ -88,7 +158,9 @@ export function StyleguidePage() {
 
       <section>
         <h3>Tile</h3>
-        <p>Tiles with title, optional status dot, optional icon link, and body slot:</p>
+        <p>
+          Surface-2 background, 1px hairline border, title on surface-3. Optional status dot and icon link.
+        </p>
         <ResponsiveGrid>
           <Tile
             title="Sensors"
@@ -122,6 +194,7 @@ export function StyleguidePage() {
 
       <section>
         <h3>Modal</h3>
+        <p>Surface-3 background, hairline border, accent-colored submit button.</p>
         <SubmitButton label="Open modal" variant="primary" onClick={() => setModalOpen(true)} />
         <Modal
           open={modalOpen}
@@ -182,9 +255,20 @@ export function StyleguidePage() {
       </section>
 
       <section>
+        <h3>Typography</h3>
+        <p>
+          UI text uses <code>var(--font-sans)</code>: system-ui, -apple-system, Roboto.{" "}
+          Code, IDs, and numeric values use <code>var(--font-mono)</code>: JetBrains Mono, Fira Code, SF Mono.
+        </p>
+        <p style={{ fontFamily: "var(--font-mono)" }}>
+          <strong>Monospace sample:</strong> 25.3°C | sensor-esp-01 | 99.7%
+        </p>
+      </section>
+
+      <section>
         <h3>Container</h3>
         <p>
-          The <code>Container</code> component is used to wrap content. It renders the <code>.container</code> class
+          The <code>Container</code> component wraps content with the <code>.container</code> class
           (max-width 1560px) and accepts <code>as</code> and <code>fluid</code> props.
         </p>
       </section>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1,53 +1,156 @@
+/* ============================================================
+   Global base styles — Warp theme.
+   Overrides token--css variables are defined in tokens.css.
+   ============================================================ */
+
 :root {
-  color-scheme: light dark;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color-scheme: dark;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
   margin: 0;
-  background: #f5f5f0;
-  color: #242b23;
+  background: var(--color-bg);
+  color: var(--color-text-primary);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5 {
+  margin: 0 0 1.25rem;
+  padding: 0;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+h1 { font-size: 1.25rem; }
+h2 { font-size: 1rem; text-transform: uppercase; letter-spacing: 0.02em; }
+h3 { font-size: 0.925rem; }
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+a:hover {
+  color: var(--color-accent-hover);
+}
+
+p {
+  margin: 0 0 1.25rem;
 }
 
 main.container {
   width: 100%;
   max-width: 1560px;
   margin: 0 auto;
-  padding: 0 1rem 2rem;
+  padding: 0 1.5rem 2rem;
 }
 
 .placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 1rem;
-  border: 1px dashed #adb5bd;
-  border-radius: 6px;
-  color: #6c757d;
-  background: #eef0ec;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-tertiary);
+  background: var(--color-surface-1);
 }
 
-.api-smoke {
-  margin-top: 1.5rem;
-  padding: 1rem;
-  border: 1px solid #ced4da;
-  border-radius: 6px;
-  background: #fff;
+.error {
+  color: var(--color-error);
 }
 
-.api-smoke .error {
-  color: #c92a2a;
+.info {
+  color: var(--color-text-secondary);
 }
 
-.api-smoke button {
-  margin-top: 0.75rem;
-  padding: 0.35rem 0.75rem;
+.success {
+  color: var(--color-success);
+}
+
+/* ----- Header / nav (legacy from Django header.css, now in React) ----- */
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 1560px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  height: 3.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.app-header__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-primary);
+}
+
+.app-header__brand a {
+  color: var(--color-text-primary);
+}
+
+.app-header__brand a:hover {
+  color: var(--color-accent);
+}
+
+.app-header__logo {
+  display: inline-flex;
+  align-items: center;
+}
+
+.app-header__logo img {
+  display: block;
+  height: 1.25rem;
+  width: 1.25rem;
 }
 
 nav.menu {
   display: flex;
-  gap: 1rem;
+  gap: 0.25rem;
   align-items: center;
 }
 
+nav.menu a {
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+nav.menu a:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-1);
+}
+
 nav.menu a.active {
-  font-weight: 600;
-  border-bottom-color: #495057 !important;
+  color: var(--color-accent);
+  background: transparent;
 }

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1,8 +1,7 @@
 /* ============================================================
-   Shared component styles for Odin frontend.
-   Ported from odin/static/css/index/base.css,
-   odin/static/css/index/sensors.css, and
-   odin/static/css/modal.css with BEM naming.
+   Shared component styles — Warp theme.
+   Consumes tokens from tokens.css.
+   Surface ladder: bg → surface-1 → surface-2 → surface-3
    ============================================================ */
 
 /* ----- Grid (responsive columns defined in responsive.css) ----- */
@@ -10,28 +9,32 @@
   display: grid;
   width: 100%;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-column-gap: 1.5rem;
-  grid-row-gap: 1.5rem;
+  grid-column-gap: var(--grid-gap);
+  grid-row-gap: var(--grid-gap);
   padding-bottom: 2rem;
 }
 
-/* ----- Tile ----- */
+/* ----- Tile (surface-2 rung) ----- */
 .tile {
   min-height: 320px;
   overflow: hidden;
-  border: 1px solid #3d3d3b;
-  background: #1a1a18;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  border-radius: var(--radius-md);
 }
 
 .tile__title {
   font-weight: 500;
   text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
   margin-bottom: 0;
-  padding: 0.75rem 1.5rem 0.75rem 1.5rem;
-  background: #242b23;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-surface-3);
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .tile__title-text {
@@ -39,44 +42,56 @@
 }
 
 .tile__icon {
-  float: right;
   display: flex;
   align-items: center;
 }
 
 .tile__icon a {
   display: inline-flex;
+  color: var(--color-text-secondary);
+}
+
+.tile__icon a:hover {
+  color: var(--color-accent);
 }
 
 .tile__body {
-  padding: 0 1.5rem 2rem 1.5rem;
+  padding: 0 1.5rem 2rem;
 }
 
-/* ----- Alive indicator ----- */
+/* ----- Loading / empty states ----- */
+.tile__loading,
+.tile__empty {
+  padding: 1.5rem 0;
+  color: var(--color-text-tertiary);
+  text-align: center;
+}
+
+/* ----- Alive indicator (status dot) ----- */
 .alive-indicator {
   display: inline-block;
   width: 8px;
   height: 8px;
-  margin: 2px 2px 4px 2px;
+  margin: 2px 2px 4px;
   border-radius: 50%;
   vertical-align: middle;
   flex-shrink: 0;
 }
 
 .alive-indicator--alive {
-  background-color: #4caf50;
+  background-color: var(--color-success);
 }
 
 .alive-indicator--cooling {
-  background-color: #007190;
+  background-color: var(--color-accent);
 }
 
 .alive-indicator--dead,
 .alive-indicator--heating {
-  background-color: #f44336;
+  background-color: var(--color-error);
 }
 
-/* ----- Modal ----- */
+/* ----- Modal (surface-3 rung) ----- */
 .modal {
   border: none;
   background: transparent;
@@ -85,16 +100,15 @@
 }
 
 .modal::backdrop {
-  background: rgba(0, 0, 0, 0.45);
+  background: rgba(0, 0, 0, 0.6);
 }
 
 .modal__body {
-  background: #1c1c1c;
-  color: #bfbfbf;
-  border: 1px solid #343a40;
-  border-radius: 8px;
-  padding: 20px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  background: var(--color-surface-3);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
   min-width: 280px;
 }
 
@@ -102,12 +116,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 12px;
-  gap: 12px;
+  margin-bottom: 0.75rem;
+  gap: 0.75rem;
 }
 
 .modal__title {
-  font-weight: bold;
+  font-weight: 600;
   font-size: 1rem;
   margin: 0;
 }
@@ -116,57 +130,74 @@
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   text-align: right;
-  color: inherit;
+  color: var(--color-text-secondary);
   padding: 0;
   line-height: 1;
+  transition: color var(--transition-fast);
+}
+
+.modal__close:hover {
+  color: var(--color-text-primary);
 }
 
 .modal form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 0.75rem;
 }
 
 .modal label {
   margin: 0;
-  font-weight: bold;
-  font-size: 1rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
 }
 
 .modal form label {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
 }
 
 .modal input[type="number"],
 .modal input[type="text"] {
   width: 100%;
-  padding: 0.25rem 0.5rem;
-  border: 1px solid #343a40;
-  border-radius: 6px;
-  font-size: 14px;
-  background: #000;
-  color: #bfbfbf;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  background: var(--color-surface-1);
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  transition: border-color var(--transition-normal);
+}
+
+.modal input[type="number"]:focus,
+.modal input[type="text"]:focus {
+  border-color: var(--color-accent);
+  outline: none;
 }
 
 .modal button[type="submit"] {
-  padding: 0.5rem;
+  padding: 0.5rem 1rem;
   border: none;
-  background: #ff5253;
+  background: var(--color-accent);
   color: #fff;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-fast);
 }
 
 .modal button[type="submit"]:hover {
-  background: #ff5253;
+  background: var(--color-accent-hover);
 }
 
 .modal__message {
-  font-size: 12px;
-  color: #ff5253;
-  min-height: 16px;
+  font-size: 0.8rem;
+  color: var(--color-error);
+  min-height: 1rem;
 }
 
 /* ----- Form primitives ----- */
@@ -187,7 +218,9 @@
 .form__label {
   display: inline;
   margin-bottom: 0.5rem;
-  font-weight: bold;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
 }
 
 .form__input {
@@ -195,90 +228,98 @@
   width: 100%;
   height: calc(2.25rem + 2px);
   padding: 0.375rem 0.75rem;
-  color: #bfbfbf;
-  background-color: #1a1a18;
+  color: var(--color-text-primary);
+  background-color: var(--color-surface-1);
   background-clip: padding-box;
-  border: 1px solid #3d3d3b;
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  transition: border-color var(--transition-normal);
 }
 
 .form__input:focus {
-  background-color: #242b23;
-  border-color: #82c38b;
-  outline: 0;
+  background-color: var(--color-surface-2);
+  border-color: var(--color-accent);
+  outline: none;
 }
 
 .form__button {
   display: inline-block;
   min-width: 7.5rem;
-  font-weight: 400;
+  font-weight: 500;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
   user-select: none;
   padding: 0.5rem 0.75rem;
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow
-    0.15s ease-in-out;
+  border-radius: var(--radius-sm);
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast),
+    border-color var(--transition-fast);
   cursor: pointer;
   font-family: inherit;
-  font-size: inherit;
+  font-size: 0.875rem;
   line-height: inherit;
   margin: 0;
 }
 
 .form__button--primary {
-  color: #ffffff;
-  background-color: #321e1d;
-  border: 1px solid #ff5253;
+  color: #fff;
+  background-color: var(--color-accent);
+  border: 1px solid var(--color-accent);
 }
 
 .form__button--primary:hover {
-  background-color: #ff5253;
+  background-color: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
 }
 
 .form__button--secondary {
-  color: #6f6f6f;
-  border: 1px solid #9f9f9f;
-  background-color: #ffffff;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface-2);
 }
 
 .form__button--secondary:hover {
-  color: #ffffff;
-  background-color: #9f9f9f;
+  color: var(--color-text-primary);
+  border-color: var(--color-border-strong);
+  background-color: var(--color-surface-3);
 }
 
 .form__button--outline {
-  color: #bf4b31;
-  border: 1px solid #bf4b31;
-  background-color: #ffffff;
+  color: var(--color-accent);
+  border: 1px solid var(--color-border);
+  background-color: transparent;
 }
 
 .form__button--outline:hover {
-  color: #ffffff;
-  background-color: #bf4b31;
-  border-color: #bf4b31;
+  color: var(--color-accent-hover);
+  border-color: var(--color-accent);
+  background-color: transparent;
 }
 
 .form__button:disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
 .form__status {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   min-height: 1rem;
 }
 
 .form__status--error {
-  color: #ff5253;
+  color: var(--color-error);
 }
 
 .form__status--info {
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .form__status--success {
-  color: #4caf50;
+  color: var(--color-success);
 }
 
 /* ----- Container variations ----- */
@@ -286,11 +327,12 @@
   max-width: 100%;
 }
 
-/* ----- Chart ----- */
-.error {
-  color: #c92a2a;
-}
-
+/* ----- Chart helpers ----- */
 .recharts-responsive-container {
   min-height: 0;
+}
+
+/* Recharts tooltip override (referenced inline in TSX, but these catch fallbacks) */
+.recharts-default-tooltip {
+  border-radius: var(--radius-sm) !important;
 }

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -1,10 +1,8 @@
 /* ============================================================
-   Responsive breakpoints for shared components.
-   Ported from odin/static/css/responsive/{mobile,small-tablet,tablet,large-tablet}.css
-   Drop dashboard-specific selectors; keep generic component rules.
+   Responsive breakpoints for shared components — Warp theme.
    ============================================================ */
 
-/* Mobile: ≤480px (Pixel 7/8) */
+/* Mobile: ≤480px */
 @media (max-width: 480px) {
   main.container,
   .container {
@@ -13,7 +11,8 @@
 
   .grid {
     grid-template-columns: 1fr;
-    grid-row-gap: 0.75rem;
+    grid-column-gap: var(--grid-gap-sm);
+    grid-row-gap: var(--grid-gap-sm);
     padding-left: 0.5rem;
     padding-right: 0.5rem;
   }
@@ -24,7 +23,7 @@
 
   .tile__title {
     padding: 0.5rem 0.75rem;
-    font-size: 0.9rem;
+    font-size: 0.8rem;
   }
 
   .tile__body {
@@ -41,18 +40,15 @@
 
   .grid {
     grid-template-columns: 1fr;
+    grid-column-gap: var(--grid-gap-sm);
     grid-row-gap: 1rem;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
   }
 
-  .tile {
-    padding: 0.75rem;
-  }
-
   .tile__title {
-    padding: 0.75rem 1rem;
-    font-size: 0.95rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8rem;
   }
 
   .tile__body {
@@ -60,7 +56,7 @@
   }
 }
 
-/* Tablet: 769-1024px (iPad Pro) */
+/* Tablet: 769-1024px */
 @media (min-width: 769px) and (max-width: 1024px) {
   main.container,
   .container {
@@ -76,12 +72,11 @@
   }
 
   .tile {
-    padding: 0.75rem 1rem;
     min-height: 280px;
   }
 
   .tile__title {
-    padding: 0.75rem 1rem;
+    padding: 0.5rem 0.75rem;
   }
 
   .tile__body {
@@ -107,7 +102,7 @@
   }
 
   .tile__title {
-    padding: 0.75rem 1.25rem;
+    padding: 0.5rem 1rem;
   }
 
   .tile__body {

--- a/frontend/src/styles/tiles.css
+++ b/frontend/src/styles/tiles.css
@@ -1,17 +1,12 @@
 /* ============================================================
-   Tile component styles for dashboard tiles.
-   Ported from odin/static/css/index/{base,sensors,boiler-room,weather,currency,misc}.css
+   Dashboard tile inner styles — Warp theme.
+   Consumes tokens from tokens.css.
    ============================================================ */
 
-.tile__loading,
-.tile__empty {
-  padding: 1rem 0;
-  color: #6c757d;
-}
-
+/* ----- Sensor list (ESP8266 tile) ----- */
 .sensor-list {
   display: block;
-  padding: 1.75rem 0;
+  padding: 1.25rem 0;
   margin: 0;
 }
 
@@ -19,41 +14,86 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 0.75rem 0;
+  padding: 0.6rem 0;
+  margin: 0;
   list-style: none;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.875rem;
+}
+
+.sensor-row:last-child {
+  border-bottom: none;
 }
 
 .sensor-row__name {
   width: 60%;
+  color: var(--color-text-primary);
 }
 
-.sensor-row__temp span,
+.sensor-row__temp {
+  font-family: var(--font-mono);
+  font-size: 0.925rem;
+  color: var(--color-text-primary);
+  min-width: 4rem;
+  text-align: right;
+}
+
+.sensor-row__temp span {
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary);
+}
+
+.sensor-row__humidity {
+  font-family: var(--font-mono);
+  font-size: 0.925rem;
+  color: var(--color-text-secondary);
+  min-width: 4rem;
+  text-align: right;
+}
+
 .sensor-row__humidity span {
-  font-size: 0.85em;
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary);
+}
+
+.sensor-row__relay {
+  display: inline-flex;
+  align-items: center;
+  min-width: 1.5rem;
 }
 
 .sensor-row__edit .edit-btn {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0.25rem;
   display: inline-flex;
   align-items: center;
+  color: var(--color-text-tertiary);
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.sensor-row__edit .edit-btn:hover {
+  color: var(--color-accent);
+  background: var(--color-surface-1);
 }
 
 /* ----- DS18B20 / Boiler Room tile ----- */
 .sensor-row-group {
   display: flex;
-  padding: 0.25rem 0;
+  padding: 0.5rem 0;
   margin: 0;
+  gap: 0.5rem;
 }
 
 .sensor-card {
-  width: 33%;
-  font-size: 1rem;
-  font-weight: bold;
+  flex: 1;
+  font-size: 0.875rem;
+  font-weight: 600;
   text-align: center;
   list-style: none;
+  color: var(--color-text-primary);
 }
 
 .sensor-card__value {
@@ -69,41 +109,62 @@
 
 .sensor-card__attrs {
   margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
 
 .sensor-card__relay {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   height: 24px;
-  margin-right: 0.5rem;
-  overflow: hidden;
   vertical-align: middle;
 }
 
 .sensor-card__name {
   width: 100px;
   margin: 0 auto 0.5rem;
+  color: var(--color-text-secondary);
+  font-weight: 400;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 
 .linked-sensor {
-  font-weight: normal;
+  font-weight: 400;
+  font-size: 0.8rem;
+  color: var(--color-text-tertiary);
   vertical-align: top;
 }
 
 .linked-sensor__arrow {
-  font-size: 1.25rem;
+  font-size: 1rem;
+  margin-right: 0.25rem;
 }
 
 /* ----- Weather tile ----- */
 .weather-temp {
-  margin-top: 1rem;
-  font-size: 3.75rem;
-  font-weight: bold;
+  margin-top: 0.75rem;
+  font-size: 3.5rem;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  line-height: 1;
+  color: var(--color-text-primary);
 }
 
 .weather-temp .meta {
-  margin: 1.5rem 2rem;
-  font-size: 1rem;
-  font-weight: normal;
+  margin: 0 0 0 1.5rem;
+  font-size: 0.8rem;
+  font-weight: 400;
+  font-family: var(--font-sans);
+  line-height: 1.5;
+  color: var(--color-text-tertiary);
+}
+
+.weather-temp .meta span {
+  color: var(--color-text-secondary);
 }
 
 .weather-temp,
@@ -112,15 +173,17 @@
   display: flex;
   flex-flow: row wrap;
   align-content: center;
-  margin-right: 2rem;
 }
 
 .weather-humidity .tile-label,
 .weather-pressure .tile-label {
   align-content: center;
   margin: 0;
-  font-weight: bold;
-  vertical-align: baseline;
+  font-weight: 500;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 
 .weather-humidity__chart img,
@@ -129,49 +192,65 @@
   margin-right: 0.5rem;
 }
 
+.weather-wind {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
 .weather-wind__direction {
   position: relative;
-  height: 3rem;
-  padding: 0 1.5rem 0 2rem;
+  height: 2.5rem;
+  width: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .weather-wind__direction span {
-  position: relative;
-  top: -0.75rem;
   display: inline-block;
-  font-size: 2.75rem;
-  font-weight: bold;
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
 }
 
 .weather-wind .label {
-  font-weight: bold;
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--color-text-primary);
+}
+
+.weather-wind .gusts {
+  font-size: 0.8rem;
+  color: var(--color-text-tertiary);
 }
 
 .weather .attr {
-  margin-left: 10%;
-  padding: 0.25rem;
+  padding: 0.25rem 0;
   line-height: 1.5;
-}
-
-.weather .attr span {
-  display: inline-block;
 }
 
 .weather .attr .tile-label {
   margin: 0;
-  font-weight: bold;
-  vertical-align: baseline;
+  font-weight: 500;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 
 /* ----- Currency tile ----- */
 .currency-date {
-  padding: 1rem 0 0;
+  padding: 1rem 0 0.25rem;
+  font-size: 0.8rem;
+  color: var(--color-text-tertiary);
 }
 
 .currency-rates {
   display: flex;
   flex-direction: column;
-  padding: 0.5rem 0;
+  padding: 0.25rem 0;
 }
 
 .currency-rate {
@@ -179,7 +258,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.5rem 0;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .currency-rate:last-child {
@@ -187,41 +266,54 @@
 }
 
 .currency-rate__code {
-  font-weight: bold;
-  font-size: 1.1rem;
+  font-weight: 600;
+  font-size: 0.925rem;
+  font-family: var(--font-mono);
   min-width: 3rem;
+  color: var(--color-text-primary);
 }
 
 .currency-rate__value {
   flex-grow: 1;
   text-align: right;
-  font-size: 1.1rem;
+  font-family: var(--font-mono);
+  font-size: 0.925rem;
   padding: 0 0 0 1rem;
+  color: var(--color-text-primary);
 }
 
 .currency-rate__value .trend {
   margin-left: 0.5rem;
+  font-size: 0.85rem;
 }
 
 .currency-rate__value .trend.up {
-  color: green;
+  color: var(--color-success);
 }
 
 .currency-rate__value .trend.down {
-  color: red;
+  color: var(--color-error);
 }
 
 /* ----- System / Errors tile ----- */
 .system-traffic {
   margin-bottom: 1rem;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
 }
 
-.system-traffic .label,
-.system-voltage .label {
+.system-traffic .label {
   display: inline-block;
   min-width: 150px;
-  text-transform: capitalize;
+  font-weight: 500;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-text-secondary);
+}
+
+.system-traffic .value {
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
 }
 
 .system-voltage {
@@ -229,6 +321,22 @@
   justify-content: flex-start;
   align-items: center;
   margin-bottom: 1rem;
+  font-size: 0.875rem;
+}
+
+.system-voltage .label {
+  display: inline-block;
+  min-width: 150px;
+  font-weight: 500;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-text-secondary);
+}
+
+.system-voltage .value {
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
 }
 
 .system-systemd {
@@ -237,30 +345,56 @@
 
 .systemd-entry {
   list-style: none;
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 0;
 }
 
 .systemd-entry__service {
   display: inline-block;
   min-width: 150px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--color-text-primary);
+}
+
+.systemd-entry__status {
+  font-size: 0.8rem;
+  color: var(--color-text-tertiary);
 }
 
 .systemd-entry__error {
-  color: #f44336;
+  font-size: 0.8rem;
+  color: var(--color-error);
+  font-family: var(--font-mono);
+}
+
+.system-errors {
+  margin-top: 0.75rem;
 }
 
 .log-entry {
   list-style: none;
+  display: flex;
+  align-items: center;
+  padding: 0.2rem 0;
+  font-size: 0.8rem;
 }
 
 .log-entry__time {
   margin-right: 1rem;
+  font-family: var(--font-mono);
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+}
+
+.log-entry__msg {
+  color: var(--color-text-secondary);
+  word-break: break-word;
 }
 
 .success.info {
   padding: 0.5rem 0;
-  color: #6c757d;
-}
-
-.info {
-  color: #6c757d;
+  color: var(--color-success);
+  font-size: 0.85rem;
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,48 @@
+/* ============================================================
+   Design tokens — Warp / Linear / Zed inspired color system.
+   Dark-first, near-black canvas, 4-step surface ladder,
+   lavender-blue accent, hairline borders, no pure black/white.
+   ============================================================ */
+
+:root {
+  /* ----- Surface ladder ----- */
+  --color-bg: #0c0d0e;
+  --color-surface-1: #0f1011;
+  --color-surface-2: #141516;
+  --color-surface-3: #1a1c23;
+
+  /* ----- Borders ----- */
+  --color-border: #23252a;
+  --color-border-strong: #34343a;
+
+  /* ----- Text ----- */
+  --color-text-primary: #f7f8f8;
+  --color-text-secondary: #8f93a2;
+  --color-text-tertiary: #62666d;
+
+  /* ----- Accent (lavender-blue) ----- */
+  --color-accent: #5e6ad2;
+  --color-accent-hover: #828fff;
+
+  /* ----- Semantic ----- */
+  --color-success: #27a644;
+  --color-error: #ff5370;
+  --color-warning: #ffcb6b;
+
+  /* ----- Typography ----- */
+  --font-sans: system-ui, -apple-system, "Segoe UI", "Roboto", sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", "SF Mono", monospace;
+
+  /* ----- Radii ----- */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+
+  /* ----- Transitions ----- */
+  --transition-fast: 0.1s ease-in-out;
+  --transition-normal: 0.15s ease-in-out;
+
+  /* ----- Grid gap ----- */
+  --grid-gap: 1.5rem;
+  --grid-gap-sm: 0.75rem;
+}

--- a/odin/static/css/modal.css
+++ b/odin/static/css/modal.css
@@ -1,10 +1,14 @@
+/* ============================================================
+   Modal styles — Warp theme (hardcoded tokens for Django static).
+   ============================================================ */
+
 .modal {
   position: fixed;
   inset: 0;
   display: none;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.45);
+  background: rgba(12, 13, 14, 0.7);
   z-index: 1000;
 }
 
@@ -13,12 +17,11 @@
 }
 
 .modal__body {
-  background: #1c1c1c;
-  color: #bfbfbf;
-  border: 1px solid #343a40;
+  background: #1a1c23;
+  color: #f7f8f8;
+  border: 1px solid #23252a;
   border-radius: 8px;
   padding: 20px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
   min-width: 280px;
   max-width: 90vw;
 }
@@ -27,7 +30,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 12px;
+  margin-bottom: 1rem;
   gap: 12px;
 }
 
@@ -36,7 +39,13 @@
   border: none;
   cursor: pointer;
   font-size: 1.5rem;
+  color: #8f93a2;
   text-align: right;
+  transition: color 0.1s ease-in-out;
+}
+
+.modal__close:hover {
+  color: #f7f8f8;
 }
 
 .modal form {
@@ -47,8 +56,9 @@
 
 .modal label {
   margin: 0;
-  font-weight: bold;
+  font-weight: 500;
   font-size: 1rem;
+  color: #8f93a2;
 }
 
 .modal form label {
@@ -58,30 +68,40 @@
 .modal input[type="number"],
 .modal input[type="text"] {
   width: 100%;
-  padding: .25rem .5rem;
-  border: 1px solid #343a40;
+  padding: .375rem .75rem;
+  border: 1px solid #23252a;
   border-radius: 6px;
   font-size: 14px;
-  background: #000;
-  color: #bfbfbf;
+  background: #0f1011;
+  color: #f7f8f8;
+}
+
+.modal input[type="number"]:focus,
+.modal input[type="text"]:focus {
+  border-color: #5e6ad2;
+  outline: 0;
+  box-shadow: 0 0 0 2px rgba(94, 106, 210, 0.25);
 }
 
 .modal button[type="submit"] {
-  padding: .5rem;
-  border: none;
-  background: #ff5253;
-  color: #fff;
+  padding: .5rem 1rem;
+  border: 1px solid #5e6ad2;
+  border-radius: 6px;
+  background: #5e6ad2;
+  color: #f7f8f8;
   cursor: pointer;
   font-size: 1rem;
+  font-weight: 500;
+  transition: background 0.15s ease-in-out;
 }
 
 .modal button[type="submit"]:hover {
-  background: #ff5253;
+  background: #828fff;
+  border-color: #828fff;
 }
 
 .modal__message {
   font-size: 12px;
-  color: #ff5253;
+  color: #ff5370;
   min-height: 16px;
 }
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "odin"
-version = "1.17.0"
+version = "1.18.0"
 description = "Django application that provides several IoT dashboards and services for Coruscant and Centax projects."
 readme = "README.md"
 requires-python = ">=3.13.6,<3.14.0"

--- a/uv.lock
+++ b/uv.lock
@@ -645,7 +645,7 @@ wheels = [
 
 [[package]]
 name = "odin"
-version = "1.17.0"
+version = "1.18.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary

Applied the **Warp theme** — a dark-first, near-black design system inspired by **Warp**, **Linear**, and **Zed** — across the entire React frontend.

### Changes

- **tokens.css** (new): 14 color tokens, typography stacks, radii, transitions, grid gaps
- **app.css**: Dark canvas (#0c0d0e), 4-step surface ladder, accent links, app-header with nav
- **components.css**: surface-2 tiles, surface-3 modals (no shadows), accent-aware forms, semantic alive indicators
- **tiles.css**: Monospace numeric values, hairline borders, semantic up/down colors
- **responsive.css**: Token-based grid gaps, refined breakpoints
- **Header.tsx**: app-header classes, monospace brand
- **MiniSparkline.tsx + TemperatureChart.tsx**: All hardcoded colors replaced with CSS variable references
- **index.html**: theme-color → #0c0d0e, removed legacy Django CSS deps
- **StyleguidePage.tsx**: Token reference table with color swatches

### Design rules enforced

- Dark near-black canvas (not pure #000)
- 4-step surface ladder (bg → surface-1 → surface-2 → surface-3)
- Hairline borders instead of shadows
- Lavender-blue accent (#5e6ad2) only on interactive elements
- Typography split: UI sans-serif + monospace for numeric/ID content
- No pure black/white backgrounds