### PR TITLE
MNT-152: Add Redis deps, settings, redis_bus.py

### DIFF
--- a/odin/apps/core/exceptions.py
+++ b/odin/apps/core/exceptions.py
@@ -4,3 +4,7 @@ class OdinException(Exception):
 
 class KafkaReadError(OdinException):
     pass
+
+
+class RedisReadError(OdinException):
+    pass

--- a/odin/apps/core/redis_bus.py
+++ b/odin/apps/core/redis_bus.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from enum import Enum
+from typing import Any
+
+import redis
+from redis.exceptions import RedisError
+
+from django.conf import settings
+
+from odin.apps.core.exceptions import RedisReadError
+
+
+logger = logging.getLogger(__name__)
+
+
+class PartitionKey(Enum):
+    SENSORS = "sensors"
+    RELAYS = "relays"
+
+
+class MessageType(Enum):
+    RELAY_STATE_UPDATE = "RELAY_STATE_UPDATE"
+    SENSOR_DATA_UPDATE = "SENSOR_DATA_UPDATE"
+
+
+class RedisBus:
+    _client: redis.Redis | None = None
+    _lock = threading.Lock()
+
+    @classmethod
+    def get_redis(cls) -> redis.Redis:
+        if cls._client is None:
+            with cls._lock:
+                if cls._client is None:
+                    cls._client = redis.Redis.from_url(settings.REDIS_URL)
+        return cls._client
+
+    @classmethod
+    def publish_message(cls, channel: str, payload: dict[str, Any]) -> bool:
+        try:
+            client = cls.get_redis()
+        except (RedisError, ValueError) as e:
+            logger.error(f"Redis error: {e}")
+            return False
+
+        try:
+            data = json.dumps(payload).encode("utf-8")
+            count = client.publish(channel, data)
+
+            logger.info(f"Published message to channel {channel} (subscribers: {count})")
+            return True
+
+        except RedisError as e:
+            logger.error(f"Redis error: {e}")
+        except (TypeError, ValueError) as e:
+            logger.error(f"Payload serialization error: {e}")
+
+        return False
+
+    @classmethod
+    def publish_relay_control(cls, relay_id: str, target_state: str) -> bool:
+        message = {"relay_id": relay_id, "target_state": target_state}
+        return cls.publish_message(settings.REDIS_RELAYS_CHANNEL, payload=message)
+
+    @classmethod
+    def get_relay_state(cls, relay_id: str) -> dict[str, Any] | None:
+        key = f"{settings.REDIS_RELAY_STATE_KEY_PREFIX}{relay_id}"
+        try:
+            raw = cls.get_redis().get(key)
+        except (RedisError, ValueError) as e:
+            raise RedisReadError from e
+
+        if raw is None:
+            return None
+
+        try:
+            state = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            raise RedisReadError from e
+
+        if not isinstance(state, dict):
+            raise RedisReadError
+
+        return state

--- a/odin/settings/base.py
+++ b/odin/settings/base.py
@@ -284,6 +284,13 @@ KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "192.168.1.100:90
 KAFKA_CORUSCANT_TOPIC = os.getenv("KAFKA_CORUSCANT_TOPIC", "coruscant")
 KAFKA_ODIN_TOPIC = os.getenv("KAFKA_ODIN_TOPIC", "odin")
 
+# Redis bus settings
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+REDIS_RELAYS_CHANNEL = os.getenv("REDIS_RELAYS_CHANNEL", "relays:control")
+REDIS_SENSORS_CHANNEL = os.getenv("REDIS_SENSORS_CHANNEL", "sensors:telemetry")
+REDIS_RELAY_STATE_KEY_PREFIX = os.getenv("REDIS_RELAY_STATE_KEY_PREFIX", "relays:state:")
+
 # Web Push settings
 
 FIREBASE_CLOUD_MESSAGING_PUBLIC_KEY = os.getenv("FIREBASE_CLOUD_MESSAGING_PUBLIC_KEY", "")

--- a/odin/tests/services/test_redis_bus.py
+++ b/odin/tests/services/test_redis_bus.py
@@ -1,0 +1,177 @@
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import pytest
+from redis.exceptions import RedisError
+
+from django.conf import settings
+
+from odin.apps.core.exceptions import RedisReadError
+from odin.apps.core.redis_bus import RedisBus
+
+
+class TestRedisBus:
+    def setup_method(self):
+        RedisBus._client = None
+
+    @patch("odin.apps.core.redis_bus.redis.Redis")
+    def test_get_redis_singleton(self, mock_redis_class):
+        """Test that get_redis returns the same instance."""
+        client1 = RedisBus.get_redis()
+        client2 = RedisBus.get_redis()
+
+        assert client1 is client2
+        assert mock_redis_class.from_url.call_count == 1
+
+    @patch("odin.apps.core.redis_bus.redis.Redis")
+    def test_get_redis_initializes_from_url(self, mock_redis_class):
+        """Test that redis client is initialized from REDIS_URL."""
+        RedisBus.get_redis()
+
+        mock_redis_class.from_url.assert_called_once()
+        call_args = mock_redis_class.from_url.call_args
+        assert call_args.args[0] == "redis://localhost:6379/0"
+
+    def test_get_redis_is_thread_safe(self):
+        """Test that concurrent get_redis calls create a single client."""
+        created = []
+        entered = threading.Event()
+        release = threading.Event()
+        barrier = threading.Barrier(2)
+
+        def from_url(*args, **kwargs):
+            created.append(object())
+            entered.set()
+            release.wait(5)
+            return object()
+
+        def call_get_redis():
+            barrier.wait(5)
+            return RedisBus.get_redis()
+
+        with patch("odin.apps.core.redis_bus.redis.Redis.from_url", side_effect=from_url):
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                future1 = executor.submit(call_get_redis)
+                future2 = executor.submit(call_get_redis)
+                assert entered.wait(5)
+                # Let the second thread pass the `_client is None` check while the
+                # first thread is still blocked inside from_url.
+                time.sleep(0.1)
+                release.set()
+                clients = [future1.result(timeout=5), future2.result(timeout=5)]
+
+        assert len(created) == 1
+        assert clients[0] is clients[1]
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_publish_message_success(self, mock_get_redis):
+        """Test successful message publishing."""
+        mock_client = MagicMock()
+        mock_get_redis.return_value = mock_client
+        mock_client.publish.return_value = 1
+
+        assert RedisBus.publish_message("test_channel", {"key": "value"})
+        assert mock_client.publish.call_count == 1
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_publish_message_redis_error(self, mock_get_redis):
+        """Test that RedisError is handled on failure."""
+        mock_client = MagicMock()
+        mock_get_redis.return_value = mock_client
+        mock_client.publish.side_effect = RedisError("Connection failed")
+
+        assert not RedisBus.publish_message("test_channel", {"key": "value"})
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_publish_message_serialization_error(self, mock_get_redis):
+        """Test that non-serializable payload returns False."""
+        mock_client = MagicMock()
+        mock_get_redis.return_value = mock_client
+
+        assert not RedisBus.publish_message("test_channel", {"key": object()})
+        mock_client.publish.assert_not_called()
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_publish_message_circular_reference_error(self, mock_get_redis):
+        """Test that circular reference payload returns False."""
+        mock_client = MagicMock()
+        mock_get_redis.return_value = mock_client
+        payload = {}
+        payload["self"] = payload
+
+        assert not RedisBus.publish_message("test_channel", payload)
+        mock_client.publish.assert_not_called()
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_publish_message_initialization_error(self, mock_get_redis):
+        """Test that client initialization failure returns False."""
+        mock_get_redis.side_effect = ValueError("Invalid REDIS_URL")
+
+        assert not RedisBus.publish_message("test_channel", {"key": "value"})
+
+    @patch("odin.apps.core.redis_bus.RedisBus.publish_message")
+    def test_publish_relay_control(self, mock_publish_message):
+        """Test publish_relay_control formats message correctly."""
+        RedisBus.publish_relay_control(relay_id="relay_1", target_state="ON")
+        assert mock_publish_message.call_count == 1
+        assert mock_publish_message.call_args.args[0] == settings.REDIS_RELAYS_CHANNEL
+        assert mock_publish_message.call_args.kwargs["payload"] == {"relay_id": "relay_1", "target_state": "ON"}
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_get_relay_state_returns_data(self, mock_get_redis):
+        """Test that get_relay_state returns data when found."""
+        mock_client = MagicMock()
+        mock_get_redis.return_value = mock_client
+        mock_client.get.return_value = b'{"relay_id": "relay_1", "state": "ON"}'
+
+        result = RedisBus.get_relay_state("relay_1")
+        assert result == {"relay_id": "relay_1", "state": "ON"}
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_get_relay_state_returns_none_when_not_found(self, mock_get_redis):
+        """Test that get_relay_state returns None when relay not found."""
+        mock_client = MagicMock()
+        mock_get_redis.return_value = mock_client
+        mock_client.get.return_value = None
+
+        assert RedisBus.get_relay_state("relay_1") is None
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_get_relay_state_raises_redis_error(self, mock_get_redis):
+        """Test that get_relay_state raises RedisReadError on failure."""
+        mock_client = MagicMock()
+        mock_get_redis.return_value = mock_client
+        mock_client.get.side_effect = RedisError("Connection failed")
+
+        with pytest.raises(RedisReadError):
+            RedisBus.get_relay_state("relay_1")
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_get_relay_state_raises_redis_error_on_initialization(self, mock_get_redis):
+        """Test that get_relay_state raises RedisReadError when client init fails."""
+        mock_get_redis.side_effect = ValueError("Invalid REDIS_URL")
+
+        with pytest.raises(RedisReadError):
+            RedisBus.get_relay_state("relay_1")
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_get_relay_state_raises_redis_error_on_invalid_json(self, mock_get_redis):
+        """Test that get_relay_state raises RedisReadError on malformed JSON."""
+        mock_client = MagicMock()
+        mock_get_redis.return_value = mock_client
+        mock_client.get.return_value = b"{invalid json"
+
+        with pytest.raises(RedisReadError):
+            RedisBus.get_relay_state("relay_1")
+
+    @patch("odin.apps.core.redis_bus.RedisBus.get_redis")
+    def test_get_relay_state_raises_redis_error_on_non_dict_payload(self, mock_get_redis):
+        """Test that get_relay_state raises RedisReadError on non-dict payload."""
+        mock_client = MagicMock()
+        mock_get_redis.return_value = mock_client
+        mock_client.get.return_value = b'"ON"'
+
+        with pytest.raises(RedisReadError):
+            RedisBus.get_relay_state("relay_1")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "odin"
-version = "1.18.0"
+version = "1.19.0"
 description = "Django application that provides several IoT dashboards and services for Coruscant and Centax projects."
 readme = "README.md"
 requires-python = ">=3.13.6,<3.14.0"
@@ -23,6 +23,7 @@ dependencies = [
     "psycopg2-binary>=2.9.12,<3",
     "pytz>=2026.2",
     "pywebpush>=2.3.0,<3",
+    "redis>=5,<6",
     "requests>=2.34.2,<3",
     "ruff>=0.15.21",
     "selenium>=4.46.0,<5",

--- a/uv.lock
+++ b/uv.lock
@@ -645,7 +645,7 @@ wheels = [
 
 [[package]]
 name = "odin"
-version = "1.18.0"
+version = "1.19.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },
@@ -662,6 +662,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pytz" },
     { name = "pywebpush" },
+    { name = "redis" },
     { name = "requests" },
     { name = "ruff" },
     { name = "selenium" },
@@ -696,6 +697,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.12,<3" },
     { name = "pytz", specifier = ">=2026.2" },
     { name = "pywebpush", specifier = ">=2.3.0,<3" },
+    { name = "redis", specifier = ">=5,<6" },
     { name = "requests", specifier = ">=2.34.2,<3" },
     { name = "ruff", specifier = ">=0.15.21" },
     { name = "selenium", specifier = ">=4.46.0,<5" },
@@ -955,6 +957,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
 name = "pysocks"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1086,11 +1097,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "8.0.1"
+version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+dependencies = [
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This pull request implements the Redis foundation for the odin project, as outlined in task MNT-152. The changes include adding Redis dependencies, settings, and a new `redis_bus.py` module, while keeping the existing Kafka code intact.

## Changes
* Added `redis` dependency to `pyproject.toml` and regenerated `uv.lock`
* Added four new environment-driven constants for Redis settings to `odin/settings/base.py`
* Created a new `RedisBus` class in `odin/apps/core/redis_bus.py` that mirrors the `kafka.py` module
* Added a new exception class `RedisReadError` to `odin/apps/core/exceptions.py`
* Created a new test file `odin/tests/services/test_redis_bus.py` that mirrors the coverage of `test_kafka.py`

## Testing
The changes were verified through the creation of new test cases in `odin/tests/services/test_redis_bus.py`, which mirror the coverage of `odin/tests/services/test_kafka.py`. The tests cover the `RedisBus` class, including publishing messages to Redis channels and getting relay state from Redis. Additionally, the acceptance criteria include running `uv run pytest` and `uv run ruff check` to ensure the code passes all tests and checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis-based messaging for publishing sensor updates and relay control commands.
  * Added relay-state retrieval with clear handling for unavailable or invalid data.
  * Added configurable Redis connection, channel, and state settings.

* **Bug Fixes**
  * Added graceful handling for Redis connection, serialization, and data errors.

* **Tests**
  * Added comprehensive coverage for Redis messaging and relay-state scenarios.

* **Chores**
  * Updated the release version to 1.19.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->